### PR TITLE
v1.0.3: compatibility with 2022.2 (and higher)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'de.dmoebius.intellij'
-version '1.0.2'
+version '1.0.3'
 
 sourceCompatibility = 1.8
 
@@ -22,9 +22,11 @@ intellij {
 }
 patchPluginXml {
     sinceBuild '191'
-    untilBuild '221.*'
+    untilBuild '224.*'
     changeNotes """
       <dl>
+        <dt>Version 1.0.3</dt>
+        <dd>compatibility with 2022.2 (and higher)</dd>
         <dt>Version 1.0.2</dt>
         <dd>compatibility with 2019.1-3 (and higher)</dd>
         <dt>Version 1.0.1</dt>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,8 +6,8 @@
     <p>
     This is a fork of the SimpleActions plugin by Etienne Studer, which is no longer maintained.
     </p>]]></description>
-    <version>1.0.2</version>
-    <idea-version since-build="191" until-build="221.*"/>
+    <version>1.0.3</version>
+    <idea-version since-build="191" until-build="240.*"/>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
     <actions>


### PR DESCRIPTION
It's time for upgrade :)
>Build #IU-222.3345.118, built on July 26, 2022